### PR TITLE
fix: set campaigns and flows to unsorted

### DIFF
--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -79,7 +79,7 @@ class CampaignsStream(KlaviyoStream):
 
     @property
     def is_sorted(self) -> bool:
-        return True
+        return False
 
 
 class ProfilesStream(KlaviyoStream):
@@ -171,7 +171,7 @@ class FlowsStream(KlaviyoStream):
     primary_keys = ["id"]
     replication_key = "updated"
     schema_filepath = SCHEMAS_DIR / "flows.json"
-    is_sorted = True
+    is_sorted = False
 
     def post_process(
         self,


### PR DESCRIPTION
Campaigns and flows do not have `sort` parameter in the Klaviyo API so sorted results are not guaranteed.
https://developers.klaviyo.com/en/reference/campaigns_api_overview
https://developers.klaviyo.com/en/reference/flows_api_overview
https://developers.klaviyo.com/en/docs/sorting_?utm_source=chatgpt.com